### PR TITLE
add proxy pass to frontend to fix production fetch issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wellness-me",
   "version": "0.1.0",
+  "proxy": "http://localhost:5000",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/components/Auth/LoginPage.jsx
+++ b/src/components/Auth/LoginPage.jsx
@@ -18,7 +18,7 @@ const LoginPage = () => {
             username: username,
             password: password
         }
-        const r = await fetch("http://localhost:5000/v1/users/login/", {
+        const r = await fetch("/v1/users/login/", {
             method: "POST",
             headers: {
                 'Content-Type': 'application/json',
@@ -50,7 +50,7 @@ const LoginPage = () => {
             "password": password,
         }
 
-        const r = await fetch("http://localhost:5000/v1/users/register", {
+        const r = await fetch("/v1/users/register", {
             method: "POST",
             headers: {
                 'Content-Type': 'application/json'

--- a/src/components/Charts/Analytics.jsx
+++ b/src/components/Charts/Analytics.jsx
@@ -19,7 +19,7 @@ const Analytics = () => {
         const username = cookies.get("username");
         setUsername(username)
 
-        const url = `http://localhost:5000/v1/data/${userid}`
+        const url = `/v1/data/${userid}`
         const r = await fetch(url, {
             method: "GET",
             headers: {

--- a/src/components/InputForms/Form.jsx
+++ b/src/components/InputForms/Form.jsx
@@ -33,7 +33,7 @@ const Form = () => {
             "happiness": daySlider,
         }
 
-        const r = await fetch("http://localhost:5000/v1/data/", {
+        const r = await fetch("/v1/data/", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",

--- a/src/components/Settings/DeleteUser.jsx
+++ b/src/components/Settings/DeleteUser.jsx
@@ -16,7 +16,7 @@ const DeleteUser = () => {
         const token = cookies.get("token");
 
 
-        const r = await fetch(`http://localhost:5000/v1/data/${userID}`, {
+        const r = await fetch(`/v1/data/${userID}`, {
             method: "DELETE",
             headers: {
                 "Authorization": "Bearer " + token


### PR DESCRIPTION
- in order to correctly use the fetch api on the frontend in production we needed to remove all instances of `http://localhost:5000` in our frontend code.  Adding a proxy pass to the package.json fixed all production issues